### PR TITLE
Point the landing page at component and internal support

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -12,6 +12,18 @@ AWI-CM3 is a coupled atmosphere ocean general circulation model (AOGCM) based on
 
 These are not separate models with separate manuals. They share their atmosphere, their ocean, their coupler and almost all of their configuration, so this documentation covers all of them in one place. A section that does not apply to every setup opens with an ``Applies to:`` line; a section without one applies everywhere. If you are not sure which setup you are running, or what the difference between AWI-CM3-v3.4 and AWI-ESM3-v3.4 is, start at :doc:`model_family`.
 
+Getting help
+============
+
+If the answer is not on this site, the components have their own public trackers, and asking the people who wrote the component is usually quicker than asking us:
+
+- FESOM2: https://github.com/FESOM/fesom2/issues
+- REcoM: https://github.com/RECOM-Regulated-Ecosystem-Model/REcoM/issues
+- esm_tools: https://github.com/esm-tools/esm_tools/issues
+- OpenIFS: ECMWF's OpenIFS space at https://confluence.ecmwf.int/display/OIFS
+
+For anything specific to AWI-CM3 or AWI-ESM3 rather than to one of its components, and for the group's own discussions, see https://github.com/AWI-ESM/project_management. Several hundred past and present issues are collected there, so it is worth searching before you ask anywhere else. That repository is private, so ask one of the AWI staff named in :doc:`before_you_start` if you cannot reach it.
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:


### PR DESCRIPTION
One section on the landing page, above the toctree.

The components have their own public trackers and the people who wrote them answer faster than we do, so the section points at FESOM2, REcoM, esm_tools and ECMWF's OpenIFS space. Every link was checked as reachable.

For anything specific to AWI-CM3 or AWI-ESM3 rather than to a component, it points at `project_management`, noted as private with a pointer to who grants access.

This addresses one of the two open items in #10, the other being the welcome email, which is outside the documentation.
