### PR TITLE
Document what LPJ-GUESS replaces and how its spinup works

### DIFF
--- a/source/how_to/lpj_guess.rst
+++ b/source/how_to/lpj_guess.rst
@@ -2,6 +2,28 @@
 LPJ-GUESS
 *********
 
+Applies to: AWI-ESM3 and its variants. AWI-CM3 has no vegetation model.
+
+There is no switch for dynamic vegetation. ``ECE_CPL_LPJG`` is on unconditionally in the AWI-ESM3 setup, so running AWI-ESM3 is running with LPJ-GUESS.
+
+What OpenIFS gets from it
+=========================
+
+On every coupling exchange LPJ-GUESS returns the vegetation type, the cover fraction and the LAI, for the low and the high vegetation tile each, and OpenIFS uses those in place of what it read at initialisation. It also stops reading the monthly LAI climatology out of the ICMCL altogether.
+
+So whatever vegetation is in the initial condition files decides only the first few steps. If you want a particular vegetation, you have to spin it up or bring it in as a restart, not write it into the ICMGG. :doc:`../paleo` covers the case where those initial fields come from a palaeogeographic reconstruction.
+
+Spin up the vegetation
+======================
+
+A new equilibrium climate needs its own spinup, of about 2000 years, run with the ``lpjg-spinup`` setup. Vegetation and the fast soil pools reach equilibrium by integration in that time. The slow soil carbon pools would need far longer, so LPJ-GUESS does not integrate them: it records litter input and decomposition over a window early in the spinup, solves the pools analytically once, and lets the rest of the run settle around the result. That is why 2000 years is enough for something whose timescale is much longer than 2000 years.
+
+The first ``freenyears`` years, 100 in the spinups run so far, deliberately run without nitrogen limitation so that a nitrogen pool can build up first.
+
+You do not need a spinup when an experiment genuinely branches from another, a scenario continuing a historic run being the obvious case. Then you take the state across, as below.
+
+The ``.ins`` files are LPJ-GUESS's own configuration and are not a knob to reach for. In practice nobody changes them, and if you are going to, you want to know the vegetation model rather than this page.
+
 Branch off from existing LPJGuess restart
 =========================================
 

--- a/source/paleo.rst
+++ b/source/paleo.rst
@@ -157,7 +157,7 @@ Vegetation on AWI-ESM3
 
 Applies to: AWI-ESM3 and its variants. On AWI-CM3 the tool's vegetation is what the atmosphere uses, and none of this applies.
 
-With LPJ-GUESS coupled, OpenIFS takes vegetation type, cover and LAI from LPJ-GUESS on every exchange, for the low and the high vegetation tile both, and stops reading the monthly LAI climatology out of the ICMCL at all. What the tool writes from the biome map is therefore an initial state and nothing more, and the ICMCL limitation noted above stops mattering.
+LPJ-GUESS overrides the vegetation OpenIFS started with, so what the tool writes from the biome map is an initial state and nothing more, and the ICMCL limitation noted above stops mattering. :doc:`how_to/lpj_guess` says what it replaces and how the spinup works in general.
 
 What you do need is a vegetation state grown under the paleo climate, rather than a modern one carried in by accident:
 


### PR DESCRIPTION
The third item of #3, use dynamic vegetation. The page was 20 lines covering only how to branch off a restart.

It now opens by saying there is no switch, since `ECE_CPL_LPJG` is unconditional in the AWI-ESM3 setup, so running AWI-ESM3 is running with LPJ-GUESS.

**What OpenIFS gets from it.** Vegetation type, cover and LAI, for the low and high tile each, on every exchange, replacing what was read at initialisation, and the ICMCL monthly LAI is not read at all. The consequence a reader needs is that writing vegetation into the ICMGG achieves nothing: you spin it up or bring it in as a restart.

**Spin up the vegetation.** A new equilibrium climate needs about 2000 years with the `lpjg-spinup` setup. The slow soil carbon pools are not integrated for that long; LPJ-GUESS records litter input and decomposition over a window early in the spinup, solves those pools analytically once, and lets the rest of the run settle around the result. That is why 2000 years suffices for something with a much longer timescale. The first `freenyears` years run without nitrogen limitation so a nitrogen pool can build first. No spinup is needed where an experiment genuinely branches, a scenario continuing a historic run being the obvious case.

Also says the `.ins` files are LPJ-GUESS's own configuration and not a knob to reach for.

The general exchange description moves here out of `paleo.rst`, which now links to it and keeps only the paleo specific part, the AMIP forcing from the time slice. It ended up on the paleo page in #30 only because that was where it was first needed.

Verified against the 2000 year TCO95 CORE3 spinup rather than the defaults, which is where the `freenyears` value comes from. Sections are 7, 11 and 19 lines. No em dashes, no bold, build unchanged at 9 warnings with none from either page.
