### PR TITLE
Document how to supply your own greenhouse gas series

### DIFF
--- a/source/how_to/forcing.rst
+++ b/source/how_to/forcing.rst
@@ -71,6 +71,57 @@ Control is analogous to CMIP6 but we use ``LCMIP5``, ``CMIP5DATADIR``, and ``NRC
 
 For a more detailed look at the use of these forcing consult the source code file ``src/ifs/climate/updrgas.F90``
 
+Supply your own greenhouse gas time series
+==========================================
+
+Applies to: everything except AWI-ESM3-cc, where CO2 is a prognostic tracer and is not read from a concentration file at all.
+
+There is no namelist entry that takes a filename. OpenIFS builds the name it wants from the scenario switch and the simulation year, and then looks for exactly that name. So a custom series is not a setting, it is a file you put where the model will look, under the name the model will construct.
+
+The recipe is the same for all three CMIP generations. Copy the pool directory somewhere you can write, replace the values in the file for the gas and years you care about, and point the data directory at your copy:
+
+.. code-block:: yaml
+
+   oifs:
+       add_namelist_changes:
+           fort.4:
+               NAERAD:
+                   CMIP6DATADIR: '/work/<project>/<user>/input/my-cmip6-data'
+
+Leave the file names alone. Renaming a file is the one thing that cannot work, because the model is not reading a name you gave it.
+
+What differs is which switch drives the name and what you are editing:
+
+- **CMIP5**, driven by ``NRCP``, cy43r3 only. Plain text, one row per year, columns ``YEAR CO2 CH4 N2O CFC11 CFC12``. Edit it in any editor. The names are fixed: ``ghg_histo.txt`` for the historical case, and ``ghg_rcp3PD.txt``, ``ghg_rcp45.txt``, ``ghg_rcp60.txt`` or ``ghg_rcp85.txt`` for the RCPs.
+- **CMIP6**, driven by ``SSPNAME``, both cycles. One NetCDF per gas, holding ``mole_fraction_of_<gas>_in_air(time, sector)``. Sector 0 is global, 1 is the northern hemisphere and 2 the southern, and all three are read, so change all three unless you actually want a hemispheric gradient.
+- **CMIP7**, driven by ``SCENARIONAME``, cy48r1 only. One NetCDF per gas, global mean only, so the variable is simply ``co2(time)``, ``ch4(time)`` and so on. These sit under ``<CMIP7DATADIR>/ghg/ScenarioMIP/`` rather than directly in the data directory.
+
+For the NetCDF cases the edit itself is one command. To scale a series, or to write your own values in from a text file:
+
+.. code-block:: bash
+
+  ncap2 -s 'co2 = co2 * 2.0' co2_in.nc co2_out.nc
+  ncap2 -s 'mole_fraction_of_carbon_dioxide_in_air(:,0) = 400.0' co2_in.nc co2_out.nc
+
+Check that the model used it
+----------------------------
+
+Almost nothing checks this for you, so check the file before you submit. ``ncdump -v co2 yourfile.nc | tail`` costs a second and catches the case where you edited the wrong gas, the wrong sector or the wrong years.
+
+The one thing the model does catch is a name it cannot find, and it does so at startup rather than silently falling back:
+
+..  code-block:: bash
+
+  ECE_CMIP_GHG: No such file or directory
+
+A scenario name that does not exist fails the same way:
+
+..  code-block:: bash
+
+  ECE_CMIP_GHG : unknown CMIP6 scenario
+
+Wrong values in a file with the right name are not caught by anything. The run starts, finishes and is wrong, so the ``ncdump`` is the only check that matters.
+
 Control Aerosol Scaling
 =======================
 

--- a/source/how_to/forcing.rst
+++ b/source/how_to/forcing.rst
@@ -108,6 +108,17 @@ Check that the model used it
 
 Almost nothing checks this for you, so check the file before you submit. ``ncdump -v co2 yourfile.nc | tail`` costs a second and catches the case where you edited the wrong gas, the wrong sector or the wrong years.
 
+Afterwards, grep ``NODE.001_01`` for ``ECE_CMIP_GHG``. It prints the full path of the file it opened and the concentration it took out of it:
+
+..  code-block:: bash
+
+  ECE_CMIP_GHG: Set JYEAR=MIN(JYEAR,2022)=        1850
+  /work/<project>/<user>/input/oifs-48r1/cmip-data//ghg/co2_input4MIPs_GHGConcentrations_CMIP_CR-CMIP-1-0-0_gm_1750-2022.nc
+  ZZ_YEARS=   182.5000
+  ZZCO2=   284.2973
+
+The path is the check that matters. If it is not your directory, the namelist change did not take, and ``ZZCO2`` then tells you which value the run is actually using.
+
 The one thing the model does catch is a name it cannot find, and it does so at startup rather than silently falling back:
 
 ..  code-block:: bash
@@ -120,7 +131,7 @@ A scenario name that does not exist fails the same way:
 
   ECE_CMIP_GHG : unknown CMIP6 scenario
 
-Wrong values in a file with the right name are not caught by anything. The run starts, finishes and is wrong, so the ``ncdump`` is the only check that matters.
+Wrong values in a file with the right name abort nothing. The run starts, finishes and is wrong, which is why the two checks above are worth the minute they cost.
 
 Control Aerosol Scaling
 =======================


### PR DESCRIPTION
The fourth item of #3. One section on the forcing page, 62 lines against neighbours at 69, 19 and 75.

The thing worth knowing is that there is no namelist entry taking a filename. OpenIFS builds the name from the scenario switch and the year and looks for exactly that, so a custom series means putting a file where the model will look under the name it will construct, and pointing `CMIP5DATADIR`, `CMIP6DATADIR` or `CMIP7DATADIR` at your copy. Renaming a file is the one thing that cannot work.

Per generation, since the format and the driving switch both differ:

- CMIP5, `NRCP`, cy43r3 only. Plain text, `YEAR CO2 CH4 N2O CFC11 CFC12`, editable in any editor.
- CMIP6, `SSPNAME`, both cycles. NetCDF, `mole_fraction_of_<gas>_in_air(time, sector)`, and all three sectors are read, so a partial edit leaves a hemispheric gradient.
- CMIP7, `SCENARIONAME`, cy48r1 only. NetCDF, global mean, `co2(time)`, and under `<CMIP7DATADIR>/ghg/ScenarioMIP/` rather than the data directory itself.

Confirmed against the source rather than assumed: `LCMIP5` appears in no cy48r1 file, `LCMIP6` in 12 and `LCMIP7` in 10, while cy43r3 has `LCMIP5` and `LCMIP6` in 6 each. So CMIP5 really is gone from 48r1.

Includes `ncap2` examples for the NetCDF edits, the two aborts you get from a wrong name or an unknown scenario, and the `ECE_CMIP_GHG` block in `NODE.001_01` that prints the path it opened and `ZZCO2`. The path is the check that matters, since a namelist change that did not take is otherwise invisible.

Gated `Applies to: everything except AWI-ESM3-cc`, where CO2 is prognostic and no concentration file is read.

Build unchanged at 9 warnings, none from the page.
