### PR TITLE
Keep the CO2 switches in one place

### DIFF
--- a/source/how_to/forcing.rst
+++ b/source/how_to/forcing.rst
@@ -40,6 +40,8 @@ Available SSPs are: ``SSP1-1.9``, ``SSP1-2.6``, ``SSP2-4.5``, ``SSP3-7.0``, ``SS
 
 The model also supports one percent increase per year and sudden four times incease of CO2 experiments through the additional logic switches ``L1PCTCO2`` and ``LA4XCO2``. The base value from which the the increase starts is set via ``NCMIPFIXYR``.
 
+For a multiple of the reference concentration other than those two fixed cases, set ``LANXCO2`` and give the factor in ``RNXCO2``. That is the usual way to specify a time slice whose CO2 is not a whole number of doublings.
+
 .. code-block:: Fortran
    
    &NAERAD

--- a/source/paleo.rst
+++ b/source/paleo.rst
@@ -145,7 +145,7 @@ What the tool does not decide for you
 
 The boundary condition files are only part of an equilibrium climate setup. You still have to set:
 
-- **Greenhouse gases.** ``NAMECECMIP`` in the OpenIFS namelist, e.g. ``NCMIPFIXYR`` for a fixed year, or ``LANXCO2``/``RNXCO2`` for a multiple of the reference concentration.
+- **Greenhouse gases.** A time slice needs concentrations chosen for it rather than a scenario year. See :doc:`how_to/forcing` for the switches.
 - **Orbit.** For a time slice you almost always want a fixed orbit rather than the default ``variable_year``, either ``ORBMODE: 'fixed_year'`` with ``ORBIY``, or the PMIP4 parameters for the period entered directly under ``ORBMODE: 'fixed_parameters'``. See :ref:`orbital_parameters` for the modes and a worked LIG example.
 - **Sea surface conditions.** For a coupled run these come from FESOM2. For an AMIP run you need SST and sea ice forcing for the time slice; a modern or pre-industrial AMIP forcing set with a paleo land-sea mask is not an equilibrium climate.
 - **Vegetation.** The tool maps biomes to vegetation type, cover and LAI in the ICMGG. The monthly LAI cycle in the ICMCL is only relocated to match the new mask, not rebuilt from the biomes. On AWI-ESM3 none of that survives the first coupling exchange, see :ref:`paleo_vegetation` below.


### PR DESCRIPTION
`paleo.rst` was naming OpenIFS namelist switches that belong on the forcing page, so the mechanics were in two places and the paleo copy is the one nobody would update.

`LANXCO2` and `RNXCO2` move to the forcing page, next to `L1PCTCO2` and `LA4XCO2`. They were only ever documented on the paleo page, so this is a gap closed as well as a duplicate removed. Every CO2 switch is now in one section.

The paleo bullet keeps the decision and links out, which is what the orbit bullet directly above it already did.

Two lines added, one changed. Build unchanged at 9 warnings.
