### PR TITLE
Document how to run an accelerated orbit

### DIFF
--- a/source/how_to/forcing.rst
+++ b/source/how_to/forcing.rst
@@ -198,6 +198,31 @@ The resulting anomaly of top of the atmosphere insolation shows the expected ano
 .. image:: ../releases/3.1/insolation_anomaly_LIG-PI_openIFS.png
    :width: 600
 
+Accelerate the orbit
+--------------------
+
+``variable_year`` advances the orbit exactly one year per model year, and ``NAMORB`` has no acceleration factor, so an accelerated orbit is not something you switch on. What you do instead is hold the orbit fixed within a leg and step it between legs, which works because esm_tools rewrites ``fort.4`` for every leg:
+
+.. code-block:: yaml
+
+   oifs:
+       orb_year_0: -9000        # orbital year at the start of the experiment
+       orb_accel: 10            # orbital years per model year
+       add_namelist_changes:
+           fort.4:
+               NAMORB:
+                   LCORBMD: true
+                   ORBMODE: 'fixed_year'
+                   ORBIY: "$(( ${oifs.orb_year_0} + (${start_date!year} - ${general.initial_date!year}) * ${oifs.orb_accel} ))"
+
+OpenIFS then computes the Berger 1978 parameters for that year itself, which is the same solution ``variable_year`` would have used. The orbit is constant inside a leg and jumps at each leg boundary, so keep the legs short enough that the jump stays smaller than the signal you are looking for.
+
+Deriving the year from the dates rather than from ``${general.run_number}`` matters, because then a restart or a change of leg length does not shift the orbit under you.
+
+Every leg prints a ``MODULE YOMORB`` block into ``NODE.001_01`` giving ``ORBMODE``, the ``ORBIY`` it used, and the eccentricity, obliquity and perihelion derived from it. Compare ``ORBIY`` between two consecutive legs, because that is the one thing worth checking: if it has not moved, the orbit is not stepping and every leg is running the same one.
+
+This has been checked in configuration only. The namelist comes out right, ``ORBIY = -9000`` on the first leg and ``-8900`` ten model years later at an acceleration of ten, but no production run has used it yet.
+
 Comparison of PI (1850) insolation for various relevant models
 --------------------------------------------------------------
 Differences between ECHAM6 and openIFS generated insolation can be deemed negligibly small. There is an overall offset of both ECHAM6 and openIFS with respect to the insolation computed from the PMIP4 PI orbit settings - that question may deserve further investigation. Note that ECHAM6 computes their modern insolation based on an internal orbit solution, i.e. the orbital parameters are never explicitly provided to the model as a forcing.


### PR DESCRIPTION
The fifth item of #3, accelerated orbit runs.

There is no acceleration factor in `NAMORB`, and `variable_year` advances the orbit exactly one year per model year (`NYEAR = ORBIY + (OYY - IA0)`). Saying so is half the value, since anyone wanting an accelerated run will otherwise go looking for the switch.

The other half is that it needs no new esm_tools code. Holding the orbit fixed within a leg and stepping `ORBIY` between legs is expressible in the existing YAML, because esm_tools rewrites `fort.4` every leg and `$(( ))` already handles date arithmetic. `${general.initial_date!syear}` is used as a namelist value in `recom.yaml` and `$(( ${start_date!year} > 2014 ))` in `echam.yaml`, so both halves were already established patterns.

Verified with two check runs rather than asserted:

- first leg, start year equal to initial year, gave `ORBIY = -9000`
- year forced to 1910 against an initial year of 1900, at acceleration 10, gave `ORBIY = -8900`

So the date extraction, the arithmetic, the multiplication and negative orbital years all work.

Also says how to confirm it in your own run. Each leg prints a `MODULE YOMORB` block into `NODE.001_01` with the `ORBIY` it used, and comparing that between two consecutive legs is the check that catches an expression which is not stepping.

Marked as verified in configuration only, since no production run has used it. Deriving the year from the dates rather than `run_number` is called out, because that is what makes it survive a restart or a change of leg length.

24 lines. Build unchanged at 9 warnings, none from the page.
